### PR TITLE
update tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "esnext",
+    "module": "esnext",
     "moduleResolution": "Node",
     "importHelpers": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
当module参数为ESNext时，import.meta无法通过类型检测，出现错误：`仅当 "--module" 选项为 "es2020"、"esnext" 或 "system" 时，才允许使用 "import. meta" 元属性`